### PR TITLE
Add the ability to specify the size of spots in the `spot` effect

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -63,6 +63,7 @@
           </label>
           <div v-show="settings.effect">
             <input class="form-input input-sm" type="range" min="0" max="100" step="5" v-model="settings.effectValue">
+            <input v-show="settings.effect === 'spot'" class="form-input input-sm" type="range" min="25" max="100" step="5" v-model="settings.spotPercent">
             <div v-show="settings.effect === 'spot'">
               <img src="https://user-images.githubusercontent.com/3139113/38300650-ed2c25c4-382f-11e8-9792-d46987eb17d1.png" ref="effect">
               <input class="form-input input-sm" type="file" @change="loadImage($event,'effect')">

--- a/demo/index.html
+++ b/demo/index.html
@@ -63,7 +63,7 @@
           </label>
           <div v-show="settings.effect">
             <input class="form-input input-sm" type="range" min="0" max="100" step="5" v-model="settings.effectValue">
-            <input v-show="settings.effect === 'spot'" class="form-input input-sm" type="range" min="25" max="100" step="5" v-model="settings.spotPercent">
+            <input v-show="settings.effect === 'spot'" class="form-input input-sm" type="range" min="25" max="100" step="5" v-model="settings.spotRatio">
             <div v-show="settings.effect === 'spot'">
               <img src="https://user-images.githubusercontent.com/3139113/38300650-ed2c25c4-382f-11e8-9792-d46987eb17d1.png" ref="effect">
               <input class="form-input input-sm" type="file" @change="loadImage($event,'effect')">

--- a/demo/index.js
+++ b/demo/index.js
@@ -56,6 +56,7 @@ const data = {
     padding: 0,
     effect: '',
     effectValue: 100,
+    spotPercent: 25,
     logo: false,
     logoType: 'image',
     logoText: 'Gerald',
@@ -133,6 +134,7 @@ new Vue({
         options.effect = {
           type: settings.effect,
           value: settings.effectValue / 100,
+          spotPercent: settings.spotPercent / 100,
         };
         if (settings.effect === 'spot') {
           options.background = [colorBack, this.$refs.effect];

--- a/demo/index.js
+++ b/demo/index.js
@@ -56,7 +56,7 @@ const data = {
     padding: 0,
     effect: '',
     effectValue: 100,
-    spotPercent: 25,
+    spotRatio: 25,
     logo: false,
     logoType: 'image',
     logoText: 'Gerald',
@@ -134,7 +134,7 @@ new Vue({
         options.effect = {
           type: settings.effect,
           value: settings.effectValue / 100,
-          spotPercent: settings.spotPercent / 100,
+          spotRatio: settings.spotRatio / 100,
         };
         if (settings.effect === 'spot') {
           options.background = [colorBack, this.$refs.effect];

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,12 @@ export interface QRCanvasEffect {
    * The foreground color for `spot` effect.
    */
   foregroundLight?: string;
+  /**
+   * The percentage of a cell that should be dedicated to the QR code data. A ratio between 0.25..1.
+   *
+   * Defaults to 0.25
+   */
+  spotPercent?: number;
 }
 
 export interface QRCanvasBaseLayer {

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,7 +115,7 @@ export interface QRCanvasEffect {
    *
    * Defaults to 0.25
    */
-  spotPercent?: number;
+  spotRatio?: number;
 }
 
 export interface QRCanvasBaseLayer {

--- a/src/util/effects.ts
+++ b/src/util/effects.ts
@@ -196,6 +196,7 @@ function renderSpot({
   const {
     value,
     foregroundLight = COLOR_WHITE,
+    spotPercent = 0.25,
   } = maskOptions;
   const context = canvasMask.getContext('2d');
   const canvasLayer = getCanvas(width);
@@ -222,7 +223,7 @@ function renderSpot({
         ) {
           fillSize = 1 - 0.1 * value;
         } else {
-          fillSize = 0.25;
+          fillSize = Math.min(1, Math.max(0.25, spotPercent));
         }
         const offset = (1 - fillSize) / 2;
         context.fillRect(

--- a/src/util/effects.ts
+++ b/src/util/effects.ts
@@ -196,7 +196,7 @@ function renderSpot({
   const {
     value,
     foregroundLight = COLOR_WHITE,
-    spotPercent = 0.25,
+    spotRatio = 0.25,
   } = maskOptions;
   const context = canvasMask.getContext('2d');
   const canvasLayer = getCanvas(width);
@@ -223,7 +223,7 @@ function renderSpot({
         ) {
           fillSize = 1 - 0.1 * value;
         } else {
-          fillSize = Math.min(1, Math.max(0.25, spotPercent));
+          fillSize = Math.min(1, Math.max(0.25, spotRatio));
         }
         const offset = (1 - fillSize) / 2;
         context.fillRect(


### PR DESCRIPTION
This adds the ability to specify the percentage of a cell that the `spot` effect should use for showing QR data. Allowing the size of the spots to be specified can make the QR code more readable for scanners while still allowing the background image to come through.

I updated `QRCanvasEffect` with an optional `spotPercent` key that defaults to `0.25`. This shouldn't be a breaking change as the key is optional and it has the same default as before. I also added another slider to the demo page to show how the `spotPercent` key effects the `spot` effect. 

[spotPercent.webm](https://github.com/user-attachments/assets/4431d16f-f0af-4d6b-ab90-a7fdb08b4f49)